### PR TITLE
Document setup and add bootstrap helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,65 @@
-# agent-overseer
+# Agent Overseer (Starter)
 
+Local OS overseer agent (macOS-first, cross-OS ready) with safe tool calls and a stable, pinned environment.
+
+## Quickstart
+
+### Option A: one-command bootstrap
+
+```bash
+./scripts/bootstrap_env.sh
+```
+
+This creates a `.venv`, installs locked Python dependencies, and copies `agent_core/.env.example` to `agent_core/.env` if you have not configured it yet.
+
+### Option B: manual setup
+
+1. **Create a Python virtual environment** and activate it:
+
+   ```bash
+   python3 -m venv .venv
+   source .venv/bin/activate
+   ```
+
+2. **Install dependencies**:
+
+   ```bash
+   pip install -r agent_core/requirements.lock.txt
+   ```
+
+3. **Set up your environment variables**. Copy the example env file and set the `MODEL_ID` to the tag of the local model you have available in Ollama. Example:
+
+   ```bash
+   cp agent_core/.env.example agent_core/.env
+   # then edit agent_core/.env to choose your MODEL_ID, e.g. gpt-oss:20b-q4_0
+   ```
+
+4. **Run the development server** using the supplied `Makefile`:
+
+   ```bash
+   make dev
+   ```
+
+   This starts a FastAPI server on `http://127.0.0.1:8000` with hot-reload.
+
+## Features
+
+- **Read-first, confirm-later policy** – The agent collects system information and proposes a plan before making changes. Write operations require explicit confirmation.
+- **System mapping** – Gather OS, CPU, memory, disk, network, and process information into a local SQLite database via the `sys_info` tool.
+- **Modular tools** – Utilities for reading files (`fs_read`), mapping system state (`sys_info`), searching logs (`logs_query`), and planning/executing changes (`plan_exec`).
+- **Extensible architecture** – Add new tools or extend existing ones by implementing functions in `agent_core/agent/tools` and registering them in `TOOLS`.
+- **Cross-platform ready** – Designed for macOS initially; abstractions and prompts make it straightforward to add Linux and Windows support.
+
+## Development
+
+- The code lives in the `agent_core` package. The entrypoint for the FastAPI application is `agent_core/app.py`.
+- Use `make dev` to run the API locally with auto-reload.
+- Use `make zip` to generate a zip archive of the repository (excluding virtual environments and node modules).
+
+## Safety considerations
+
+The starter implementation does **not** execute any system modifications. The `plan_exec.execute` function logs the confirmation but returns a dry-run response. Before enabling write operations you should implement proper permission checks and command execution logic, and always keep the user in control.
+
+## License
+
+This repository is provided as a reference implementation and is open for you to build upon. See the LICENSE file (to be added) for terms of use.

--- a/scripts/bootstrap_env.sh
+++ b/scripts/bootstrap_env.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Bootstrap a local development environment for Agent Overseer.
+#
+# This script creates a Python virtual environment, installs the required
+# dependencies, and copies the example environment file so you can
+# configure the Ollama host and model ID. It is safe to run multiple times.
+
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r agent_core/requirements.lock.txt
+if [ ! -f agent_core/.env ]; then
+  cp agent_core/.env.example agent_core/.env
+fi
+echo "Environment prepared. Edit agent_core/.env as needed and run 'make dev' to start the server."

--- a/scripts/zip_repo.sh
+++ b/scripts/zip_repo.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
-cd ..
-zip -r agent-overseer.zip agent-overseer \
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_NAME="$(basename "${REPO_ROOT}")"
+
+cd "${REPO_ROOT}/.."
+zip -r "${REPO_NAME}.zip" "${REPO_NAME}" \
   -x "*/__pycache__/*" "*/.venv/*" "*/node_modules/*" "*/.DS_Store"
-echo "Created agent-overseer.zip"
+echo "Created ${REPO_NAME}.zip"


### PR DESCRIPTION
## Summary
- expand the README with quickstart instructions, feature overview, and safety notes
- add a bootstrap script that prepares a virtual environment and copies the sample env file
- update the zip helper to detect the repository directory dynamically

## Testing
- ./scripts/bootstrap_env.sh

------
https://chatgpt.com/codex/tasks/task_e_68ccc515a41c8321a5c9ea2311452fb5